### PR TITLE
test: Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Run test on Ubuntu, Windows, and MacOS with Python 3.9 to 3.11
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Python
+      run: |
+        make install
+    - name: Run tests
+      run: |
+        make test


### PR DESCRIPTION
- Create a new GitHub Actions workflow to run tests on Ubuntu, Windows, and MacOS
- Test matrix includes Python versions 3.9, 3.10, and 3.11
- Workflow triggers on push and pull requests to the `main` branch
- Steps include setting up Python, installing dependencies, and running tests

No side effects expected.